### PR TITLE
Use aliased joins so that the same table can be joined twice.

### DIFF
--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -53,7 +53,7 @@ class DataTable(object):
             self.columns_dict[d.name] = d
 
         for column in (col for col in self.columns if "." in col.model_name):
-            self.query = self.query.join(column.model_name.split(".")[0])
+            self.query = self.query.join(column.model_name.split(".")[0], aliased=True)
 
     def query_into_dict(self, key_start):
         returner = defaultdict(dict)


### PR DESCRIPTION
Fixes a failure to join the same table twice when a model has two or more relationships to the same table.