### PR TITLE
Support for -1 length type. (Means All records)

### DIFF
--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -135,7 +135,7 @@ class DataTable(object):
         total_records = query.count()
 
         if callable(self.search_func) and search.get("value", None):
-            query = self.search_func(query, str(search["value"]))
+            query = self.search_func(query, search["value"])
 
         for order in ordering.values():
             direction, column = order["dir"], order["column"]

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -157,7 +157,9 @@ class DataTable(object):
             query = query.order_by(model_column.desc() if direction == "desc" else model_column.asc())
 
         filtered_records = query.count()
-        query = query.slice(start, start + length)
+
+        if length > 0:
+            query = query.slice(start, start + length)
 
         return {
             "draw": draw,


### PR DESCRIPTION
`lengthMenu` option  `-1` adaptation. `-1` should return all values without pagination.

> The page length values must always be integer values > 0, with the sole exception of -1. When -1 is used as a value this tells DataTables to disable pagination (i.e. display all rows).

See: [https://datatables.net/reference/option/lengthMenu](url)
